### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#google-map-react examples
+# google-map-react examples
 This project is isomorphic ~~Flummox~~ [redux](https://github.com/gaearon/redux) app with [google-map-react](https://github.com/istarkov/google-map-react) control examples.
 
 It also uses [non-standard approach](https://github.com/istarkov/google-map-react-examples/blob/master/docs/routing.md) for routing.   
@@ -7,10 +7,10 @@ Other docs.
 
 ---
 
-##Install
+## Install
 I highly recommend to use docker for development.
 
-###For non docker users
+### For non docker users
 * Install   
   ```bash
   npm install  
@@ -49,7 +49,7 @@ I highly recommend to use docker for development.
 ---
 
 
-###For docker users:
+### For docker users:
 * Install   
   ```bash
   ./docker/base_image/build.sh
@@ -82,7 +82,7 @@ I highly recommend to use docker for development.
 ---
 
 
-#For Docker OSX users:
+# For Docker OSX users:
 * install watchman   
   ```bash
   brew install watchman
@@ -105,7 +105,7 @@ I highly recommend to use docker for development.
 * install boot2docker with nfs support (vboxfs is really-really slow) 
 
 
-#gh-pages generation
+# gh-pages generation
 ```
 ./docker_run.sh --serverpath '/google-map-react' --production
 denter gmr

--- a/docs/isomorphic.md
+++ b/docs/isomorphic.md
@@ -1,6 +1,6 @@
-###difference between server and client rendering
+### difference between server and client rendering
 Start [here](https://github.com/istarkov/google-map-react-examples/blob/master/web/isomorphic_render.js) to see what the difference between server and client rendering
 
 
-###Not written yet.
+### Not written yet.
 ...

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -1,12 +1,12 @@
-##Routing approach
+## Routing approach
 
-###IMHO:
+### IMHO:
 Where is no need in 90% of web apps to use reach api routing libraries.
 
-###SOLUTION IN SHORT:
+### SOLUTION IN SHORT:
 Bind `onRouteChangeCallback` on `flux action`.
 
-###SOLUTION WITH EXAMPLES:
+### SOLUTION WITH EXAMPLES:
 For client-server solution router must expose two functions with (*plus-minus*) next interfaces
   1. `gotoRoute(url)` for client side
   2. `router(routePathes, initialRouteDispatch, onRouteChangeCallback)` for server and client side   

--- a/osx/touch_helper.md
+++ b/osx/touch_helper.md
@@ -1,1 +1,1 @@
-#help file for touches
+# help file for touches

--- a/web/flux/components/controls/fixed_table/README.md
+++ b/web/flux/components/controls/fixed_table/README.md
@@ -1,4 +1,4 @@
-#CAUTION: 
+# CAUTION: 
 This is just a fast hack over this control http://facebook.github.io/fixed-data-table/ .
 I did it for reactmap example only.
-###I don't think that this control production ready.
+### I don't think that this control production ready.

--- a/web/sass/node_modules/animate-sass/README.md
+++ b/web/sass/node_modules/animate-sass/README.md
@@ -1,21 +1,21 @@
-#animate-scss
+# animate-scss
 *Sassy just-add-water CSS animation*
 
 `animate-sass` is a Sass version of [Dan Eden's](https://github.com/daneden) [Animate.css](https://daneden.me/animate/).
 
-##Features
+## Features
 animate-sass has a couple of features to make the most of what Sass has to offer for more effecient development.
 
-###Helpers
+### Helpers
 
-####Mixins
+#### Mixins
 There are a couple of [Sass mixins](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#mixins) that some of the modules use to generate the necessary compiled css.
 
-####Settings
+#### Settings
 The settings file defines a range of default [Sass variables](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#variables_) which are used by some of the animation modules. You can override the defaults in your own settings or style sass file(s).
 
 
-####Animation Module loading
+#### Animation Module loading
 The settings file also sets all animation modules to false (nothing gets loaded).
 
 To include an animation module in your project, simply override the $use[moduleName] variable in your own settings file to true.
@@ -43,7 +43,7 @@ Modules are arranged by the following animation types;
 - special
 
 
-####Base Styles
+#### Base Styles
 
 There is a small section at the bottom of the `_animate.scss` file that contains the base css rules for animate.sass to work.
 
@@ -64,11 +64,11 @@ body {
 
 ````
 
-###Animations
+### Animations
 
 All individual animation modules are kept in their own [Sass partials](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#partials) so they can be found easily. You shouldn't need to edit these as they are part of the animate.css library.
 
-###Bower Support
+### Bower Support
 Add animate-sass to your project using [Bower](http://bower.io)
 
 bower.json dependency
@@ -82,7 +82,7 @@ Command line
 `bower install animate-sass`
 
 
-##Usage
+## Usage
 
 To use animate.scss in your project, you will need to have Sass installed. [Visit the Sass site](http://sass-lang.com/) to find out how to do this.
 
@@ -108,22 +108,22 @@ Finally in your markup, simply add the class `animated` to an element, along wit
 That's it! You've got a CSS animated element. Super!
 
 
-##License
+## License
 
 Animate.scss is licensed under the MIT license. [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
 
 
-##Questions/Comments
+## Questions/Comments
 
 You can follow me / ask questions on twitter: [@tom_gillard](http://www.twitter.com/tom_gillard)
 
 
-##Learn more
+## Learn more
 
 You can [check out the original animate.css here](http://daneden.me/animate). See working examples as well as how to use with javascript or creating custom css classes
 
 
-##Changelog
+## Changelog
 
 v0.6.3 - Removed Sass deprecation warnings about unquote().
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
